### PR TITLE
店舗情報取得APIとの接続と画面遷移の実装

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.18.126",
         "@types/react": "^19.1.7",
         "@types/react-dom": "^19.1.6",
+        "axios": "^1.9.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
@@ -24,6 +25,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/axios": "^0.9.36",
         "@types/react-router-dom": "^5.3.3",
         "tailwindcss": "^3.4.17"
       }
@@ -3579,6 +3581,13 @@
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "license": "MIT"
     },
+    "node_modules/@types/axios": {
+      "version": "0.9.36",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
+      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4959,6 +4968,33 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -13713,6 +13749,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.7",
     "@types/react-dom": "^19.1.6",
+    "axios": "^1.9.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
@@ -43,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "@types/axios": "^0.9.36",
     "@types/react-router-dom": "^5.3.3",
     "tailwindcss": "^3.4.17"
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,13 @@
 import { BrowserRouter } from 'react-router-dom';
 import AppRoutes from './Routes/AppRoutes';
+import { AuthProvider } from './Contexts/AuthContext'; // ここ重要！
 
 function App() {
   return (
     <BrowserRouter>
-      <AppRoutes />
+      <AuthProvider>  {/* 👈 これで全体を囲む */}
+        <AppRoutes />
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/Contexts/AuthContext.tsx
+++ b/frontend/src/Contexts/AuthContext.tsx
@@ -1,1 +1,31 @@
-export {};
+import { createContext, useState, ReactNode } from 'react';
+
+type AuthContextType = {
+  user: any;
+  token: string;
+  login: (token: string, user: any) => void;
+  logout: () => void;
+};
+
+export const AuthContext = createContext<AuthContextType | null>(null);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState('');
+
+  const login = (token: string, user: any) => {
+    setUser(user);
+    setToken(token);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken('');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/Features/Host/Pages/Home.tsx
+++ b/frontend/src/Features/Host/Pages/Home.tsx
@@ -1,20 +1,36 @@
-// src/Features/Host/Pages/Home.tsx
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchStoreInfo } from '../../../Services/StoreService';
+import { useAuth } from '../../../Hooks/UseAuth';
 
 const Home = () => {
+  const navigate = useNavigate();
+  const { token, user } = useAuth();
+
+  const handleStoreInfoClick = async () => {
+    try {
+      const storeData = await fetchStoreInfo(user.company_id, token);
+      console.log('取得した店舗情報:', storeData);
+
+      // 遷移 + state 渡す
+      navigate('/host/store-info', { state: { storeData } });
+    } catch (error) {
+      alert('店舗情報の取得に失敗しました');
+      console.error(error);
+    }
+  };
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">オーナー用ホーム</h1>
-      <ul className="space-y-2">
-        <li className="border p-4 rounded shadow">📅 シフト作成</li>
-        <li className="border p-4 rounded shadow">🏪 店舗情報編集</li>
-        <li className="border p-4 rounded shadow">👥 従業員管理</li>
-        <li className="border p-4 rounded shadow">🤖 Gemini で相談</li>
-      </ul>
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">ホーム画面（ホスト）</h1>
+      <button
+        onClick={handleStoreInfoClick}
+        className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+      >
+        店舗情報へ
+      </button>
     </div>
   );
 };
 
 export default Home;
-
-export {}; // モジュール化のためのダミーエクスポート

--- a/frontend/src/Features/Host/Pages/StoreInfo.tsx
+++ b/frontend/src/Features/Host/Pages/StoreInfo.tsx
@@ -1,1 +1,36 @@
-export {};
+// src/Features/Host/Pages/StoreInfo.tsx
+
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const StoreInfo = () => {
+  const location = useLocation();
+  const [storeData, setStoreData] = useState<any>(null);
+
+  useEffect(() => {
+    if (location.state?.storeData) {
+      setStoreData(location.state.storeData);
+    }
+  }, [location.state]);
+
+  if (!storeData) {
+    return <div className="p-4">店舗情報を読み込み中...</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">店舗情報</h1>
+      <ul className="space-y-2">
+        <li><strong>会社名：</strong>{storeData.company_name}</li>
+        <li><strong>所在地：</strong>{storeData.store_locate}</li>
+        <li><strong>営業時間：</strong>{storeData.open_time} 〜 {storeData.close_time}</li>
+        <li><strong>売上目標：</strong>{storeData.target_sales}円</li>
+        <li><strong>人件費：</strong>{storeData.labor_cost}円</li>
+        <li><strong>定休日：</strong>{storeData.rest_day.join(', ')}</li>
+        <li><strong>ポジション：</strong>{storeData.position_name.join(', ')}</li>
+      </ul>
+    </div>
+  );
+};
+
+export default StoreInfo;

--- a/frontend/src/Hooks/UseAuth.ts
+++ b/frontend/src/Hooks/UseAuth.ts
@@ -1,1 +1,14 @@
-export {};
+import { useContext } from 'react';
+import { AuthContext } from '../Contexts/AuthContext';
+
+// src/Hooks/UseAuth.ts
+
+export const useAuth = () => {
+  return {
+    user: {
+      company_id: 'dummy_company',
+      // その他使わない項目は省略OK
+    },
+    token: 'dummy_token'
+  };
+};

--- a/frontend/src/Routes/AppRoutes.tsx
+++ b/frontend/src/Routes/AppRoutes.tsx
@@ -1,10 +1,12 @@
 import { Routes, Route } from 'react-router-dom';
-import HostHome from '../Features/Host/Pages/Home'; // あなたのホーム画面
+import HostHome from '../Features/Host/Pages/Home';
+import StoreInfo from '../Features/Host/Pages/StoreInfo';
 
 const AppRoutes = () => {
   return (
     <Routes>
       <Route path="/host/home" element={<HostHome />} />
+      <Route path="/host/store-info" element={<StoreInfo />} />
     </Routes>
   );
 };

--- a/frontend/src/Services/StoreService.ts
+++ b/frontend/src/Services/StoreService.ts
@@ -1,1 +1,17 @@
-export {};
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:8000'; // FastAPIモックのURL
+
+export const fetchStoreInfo = async (companyId: string, token: string) => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/company-info`, {
+      params: { company_id: companyId },
+      headers: {
+        Authorization: `Bearer ${token}`, // トークン付きでリクエスト
+      },
+    });
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
•ホスト用ホーム画面（/host/home）に「店舗情報へ」ボタンを実装
•ボタン押下時に、FastAPI経由で店舗情報を取得
•取得した情報を保持したまま /host/store-info に画面遷移
•遷移先では受け取った情報を簡易表示（今後UI整備予定）